### PR TITLE
Harden related_docs parsing in SmartQueryEngine and add code review notes

### DIFF
--- a/CODE_REVIEW.md
+++ b/CODE_REVIEW.md
@@ -1,0 +1,29 @@
+# Code Review Notes
+
+Scope: `src/index.ts`, `src/smart-query.ts`, `src/error-db.ts`.
+
+## ✅ Strengths
+- **Clear separation of concerns**: the MCP server, smart query engine, and error database are cleanly separated into different modules, which makes maintenance easier.
+- **Helpful operator output**: the server logs index and DB stats on startup, which is useful for troubleshooting and operational visibility.
+- **Local-first design**: document indexing and error storage are fully local, avoiding external dependencies and reducing runtime costs.
+
+## ⚠️ Findings & Recommendations
+1. **`related_docs` parsing could crash on malformed JSON**
+   - In the smart query path, `related_docs` is parsed with `JSON.parse` without validation. Any malformed value can throw and fail the request.
+   - ✅ **Addressed**: added safe parsing logic that accepts JSON arrays or single strings and fails gracefully.
+
+2. **Index collisions for same-named files across multiple roots**
+   - The index is keyed by filename without extension; identical names across repositories will overwrite earlier entries.
+   - **Suggestion**: consider extending keys with repo namespace or retaining a list of matches per key.
+
+3. **Broad `LIKE` queries in error search**
+   - `searchSimilarErrors` combines terms with `AND`, which can be too strict for multi-term queries and may miss relevant errors.
+   - **Suggestion**: consider `OR` or a weighted scoring approach to balance recall and precision.
+
+4. **Document truncation thresholds are fixed**
+   - Truncation limits (10k/15k characters) are hard-coded; this could be tuned per mode or exposed as configuration.
+
+## Summary
+- The core architecture is solid and easy to follow.
+- The most important runtime risk (JSON parsing in smart query) has been mitigated.
+- Future improvements should focus on index collision handling and search flexibility.

--- a/src/smart-query.ts
+++ b/src/smart-query.ts
@@ -414,6 +414,19 @@ export class SmartQueryEngine {
       if (dbResults.length > 0) {
         // 找到历史错误记录,直接返回
         const topError = dbResults[0];
+        let relatedDocs: string[] = [];
+        if (topError.related_docs) {
+          try {
+            const parsed = JSON.parse(topError.related_docs);
+            if (Array.isArray(parsed)) {
+              relatedDocs = parsed.filter((item): item is string => typeof item === "string");
+            } else if (typeof parsed === "string") {
+              relatedDocs = [parsed];
+            }
+          } catch {
+            relatedDocs = [];
+          }
+        }
         const answer = `🔍 **从错误数据库找到解决方案** (出现${topError.occurrence_count}次)\n\n` +
           `**错误:** ${topError.error_code} - ${topError.error_message}\n\n` +
           (topError.solution ? `**解决方案:**\n${topError.solution}\n\n` : '') +
@@ -424,7 +437,7 @@ export class SmartQueryEngine {
           type: mode,
           answer,
           reference: "错误数据库",
-          relatedDocs: topError.related_docs ? JSON.parse(topError.related_docs) : [],
+          relatedDocs,
           estimatedTokens: answer.length / 4,
         };
       }


### PR DESCRIPTION
### Motivation
- Prevent runtime failures when `related_docs` stored in the local error database is malformed JSON, and capture review findings for the core modules.

### Description
- Add robust parsing in `SmartQueryEngine.query` that safely converts `topError.related_docs` into a `string[]`, accepting JSON arrays or single strings and falling back to an empty array on parse errors.
- Replace the previous direct `JSON.parse(...)` usage with the new guarded logic and return the normalized `relatedDocs` in the result object.
- Add `CODE_REVIEW.md` containing review notes and recommendations covering `src/index.ts`, `src/smart-query.ts`, and `src/error-db.ts`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b6b7750e88321915f7f7d25896c5d)